### PR TITLE
Fix sign commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run cargo release patch (version bump only)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release patch --execute --no-confirm
+        run: cargo release patch --execute --no-confirm --no-push --no-tag --no-publish
       - name: Extract version from Cargo.toml
         id: extract_version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,14 +77,16 @@ jobs:
       - name: Run cargo release patch (version bump only)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release patch --execute --no-confirm --no-push --no-tag --no-publish
+        run: cargo release patch --execute --no-confirm # commits but we dont want to commit using cargo-release, so we will git reset soft HEAD~1
       - name: Extract version from Cargo.toml
         id: extract_version
         run: |
           version=$(cargo metadata --no-deps --format-version 1 --manifest-path crates/cli/Cargo.toml | jq -r '.packages[0].version')
           echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Commit and push version bump
+
+      - name: Commit and push version bump # We first reset the last commit to avoid the commit made by cargo-release
         run: |
+          git reset --soft HEAD~1
           git add -A
           git commit -m "chore: release v${{ steps.extract_version.outputs.version }}"
           git push origin main

--- a/.release.toml
+++ b/.release.toml
@@ -2,7 +2,7 @@
 workspace = true
 
 # General settings - only for version bumping, GitHub workflow handles the rest
-consolidate-commits = false   # Don't consolidate since we're not pushing
+consolidate-commits = true
 push = false                  # We handle pushing in GitHub workflow
 tag = false                   # We handle tagging in GitHub workflow
 publish = false               # We handle publishing in GitHub workflow
@@ -10,5 +10,4 @@ allow-branch = ["main"]
 dependent-version = "upgrade" # upgrade version for dependent crates
 
 [release]
-changelog = "CHANGELOG.md"
 update-workspace-dependencies = true

--- a/.release.toml
+++ b/.release.toml
@@ -2,7 +2,7 @@
 workspace = true
 
 # General settings - only for version bumping, GitHub workflow handles the rest
-consolidate-commits = true
+consolidate-commits = false   # Don't consolidate since we're not pushing
 push = false                  # We handle pushing in GitHub workflow
 tag = false                   # We handle tagging in GitHub workflow
 publish = false               # We handle publishing in GitHub workflow
@@ -12,7 +12,3 @@ dependent-version = "upgrade" # upgrade version for dependent crates
 [release]
 changelog = "CHANGELOG.md"
 update-workspace-dependencies = true
-
-# Remove git and github settings since we handle releases in workflow
-# [git] - removed
-# [packages.*] tag-name settings - removed since we don't create tags here


### PR DESCRIPTION
`cargo release` automatically commits the version bumps, and this cannot be changed. So we let it, but git reset soft it, so that we can commit it and sign it in the Github workflow.