### PR TITLE
feat: deduct vendor-country bank holidays from billable days

### DIFF
--- a/crates/cli/src/input/tui/helpers/build_service_fees.rs
+++ b/crates/cli/src/input/tui/helpers/build_service_fees.rs
@@ -1,4 +1,4 @@
-use inquire::{CustomType, Text, error::InquireResult};
+use inquire::{Confirm, CustomType, Text, error::InquireResult};
 
 use crate::{
     Cadence, Granularity, InvoiceDataFromTuiError, Rate, Result, ServiceFees, UnitPrice,
@@ -33,10 +33,19 @@ pub fn build_service_fees(default: &ServiceFees) -> Result<ServiceFees> {
 
         let rate = Rate::from((unit_price, granularity));
 
+        let off_on_bank_holidays = Confirm::new("Off on bank holidays?")
+            .with_help_message(
+                "If yes, public holidays in the vendor's country are deducted from billable \
+                 working days (day/hour rates only). Looked up online and cached.",
+            )
+            .with_default(*default.off_on_bank_holidays())
+            .prompt()?;
+
         Ok(ServiceFees::builder()
             .name(name)
             .cadence(cadence)
             .rate(rate)
+            .off_on_bank_holidays(off_on_bank_holidays)
             .build()
             .unwrap())
     }

--- a/crates/core-invoice/Cargo.toml
+++ b/crates/core-invoice/Cargo.toml
@@ -9,7 +9,11 @@ documentation = "https://docs.rs/klirr-core-invoice"
 repository = "https://github.com/Sajjon/klirr"
 
 [dependencies]
-klirr-foundation = { workspace = true, features = ["crypto", "exchange-rates"] }
+klirr-foundation = { workspace = true, features = [
+    "crypto",
+    "exchange-rates",
+    "bank-holidays",
+] }
 
 bon.workspace = true
 chrono.workspace = true

--- a/crates/core-invoice/src/logic/calendar_logic.rs
+++ b/crates/core-invoice/src/logic/calendar_logic.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Cadence, Date, Error, Granularity, InvoiceNumber, Quantity, RecordOfPeriodsOff, RelativeTime,
-    Result, TimestampedInvoiceNumber,
+    BankHolidays, Cadence, Date, Error, Granularity, InvoiceNumber, Quantity, RecordOfPeriodsOff,
+    RelativeTime, Result, TimestampedInvoiceNumber,
 };
 use klirr_foundation::{
     CalendarError, calculate_period_number, normalize_period_end_date_for_cadence as normalize,
@@ -145,6 +145,7 @@ pub fn calculate_invoice_number(
 ///     Granularity::Day,
 ///     Cadence::Monthly,
 ///     &RecordOfPeriodsOff::default(),
+///     &BankHolidays::default(),
 /// )
 /// .unwrap();
 ///
@@ -155,9 +156,16 @@ pub fn quantity_in_period(
     granularity: Granularity,
     cadence: Cadence,
     record_of_periods_off: &RecordOfPeriodsOff,
+    bank_holidays: &BankHolidays,
 ) -> Result<Quantity> {
-    quantity_in_period_inner(target_date, granularity, cadence, record_of_periods_off)
-        .map_err(map_calendar_error)
+    quantity_in_period_inner(
+        target_date,
+        granularity,
+        cadence,
+        record_of_periods_off,
+        bank_holidays,
+    )
+    .map_err(map_calendar_error)
 }
 
 #[cfg(test)]

--- a/crates/core-invoice/src/logic/prepare_data/bank_holidays.rs
+++ b/crates/core-invoice/src/logic/prepare_data/bank_holidays.rs
@@ -1,0 +1,89 @@
+use crate::{BankHolidays, CountryCode, Data, Date};
+use log::{debug, warn};
+
+/// The disk-cached bank-holiday fetcher, re-exported from the foundation crate.
+pub type BankHolidaysFetcher<T = ()> = klirr_foundation::BankHolidaysFetcher<T>;
+
+/// Resolves the public holidays to deduct from billable days for an invoice,
+/// degrading gracefully so holiday lookup never blocks PDF generation.
+///
+/// Returns an empty set (no deduction) when:
+/// - the vendor has not opted into `off_on_bank_holidays`,
+/// - the vendor's free-text country cannot be mapped to an ISO country code, or
+/// - the holiday API request fails (and nothing is cached).
+///
+/// Otherwise it returns the (possibly cached) holidays for the vendor's country
+/// in the invoice period's year.
+pub fn resolve_bank_holidays(data: &Data, target_period_end_date: &Date) -> BankHolidays {
+    if !data.service_fees().off_on_bank_holidays() {
+        return BankHolidays::default();
+    }
+
+    let country_name = data.vendor().postal_address().country();
+    let Some(country_code) = CountryCode::from_country_name(country_name) else {
+        warn!(
+            "off_on_bank_holidays is enabled but vendor country '{country_name}' could not be \
+             resolved to an ISO country code; skipping bank-holiday deduction."
+        );
+        return BankHolidays::default();
+    };
+
+    let year = *target_period_end_date.year();
+    debug!("Resolving bank holidays for {country_code} {year}.");
+    match BankHolidaysFetcher::default().holidays_for(&country_code, year) {
+        Ok(holidays) => holidays,
+        Err(error) => {
+            warn!(
+                "Failed to fetch bank holidays for {country_code} {year}: {error}. \
+                 Skipping bank-holiday deduction."
+            );
+            BankHolidays::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{HasSample, ServiceFees};
+    use test_log::test;
+
+    #[test]
+    fn disabled_flag_returns_empty() {
+        // Sample data has off_on_bank_holidays = false.
+        let data = Data::sample();
+        let period_end = Date::sample();
+        assert!(resolve_bank_holidays(&data, &period_end).is_empty());
+    }
+
+    #[test]
+    fn enabled_with_unresolved_country_returns_empty_without_network() {
+        // A vendor whose country cannot be mapped must degrade to empty without
+        // attempting (or depending on) any network call.
+        let service_fees = ServiceFees::builder()
+            .name("Consulting".to_string())
+            .rate(crate::Rate::daily(rust_decimal::dec!(100.0)))
+            .cadence(crate::Cadence::Monthly)
+            .off_on_bank_holidays(true)
+            .build()
+            .unwrap();
+
+        let vendor = crate::CompanyInformation::sample_vendor();
+        let address = vendor
+            .postal_address()
+            .clone()
+            .with_country("Atlantis".to_string());
+        let vendor = vendor.with_postal_address(address);
+
+        let data = Data::builder()
+            .information(crate::ProtoInvoiceInfo::sample())
+            .vendor(vendor)
+            .client(crate::CompanyInformation::sample_client())
+            .payment_info(crate::PaymentInformation::sample())
+            .service_fees(service_fees)
+            .expensed_periods(crate::ExpensedPeriods::sample())
+            .build();
+
+        assert!(resolve_bank_holidays(&data, &Date::sample()).is_empty());
+    }
+}

--- a/crates/core-invoice/src/logic/prepare_data/mod.rs
+++ b/crates/core-invoice/src/logic/prepare_data/mod.rs
@@ -1,6 +1,8 @@
+mod bank_holidays;
 mod exchange_rates;
 #[allow(clippy::module_inception)]
 mod prepare_input_data;
 
+pub use bank_holidays::*;
 pub use exchange_rates::*;
 pub use prepare_input_data::*;

--- a/crates/core-invoice/src/logic/prepare_data/prepare_input_data.rs
+++ b/crates/core-invoice/src/logic/prepare_data/prepare_input_data.rs
@@ -1,6 +1,6 @@
 use crate::{
     Currency, Data, ExchangeRates, ExchangeRatesMap, Item, LineItemsPricedInSourceCurrency,
-    PreparedData, Result, ValidInput,
+    PreparedData, Result, ValidInput, normalize_period_end_date_for_cadence, resolve_bank_holidays,
 };
 use log::debug;
 use log::info;
@@ -32,7 +32,10 @@ pub fn prepare_invoice_input_data(
     fetcher: impl FetchExchangeRates,
 ) -> Result<PreparedData> {
     info!("Preparing invoice input data for PDF generation...");
-    let partial = data.to_partial(input)?;
+    let cadence = *data.service_fees().cadence();
+    let target_period_end_date = normalize_period_end_date_for_cadence(*input.date(), cadence)?;
+    let bank_holidays = resolve_bank_holidays(&data, &target_period_end_date);
+    let partial = data.to_partial(input, &bank_holidays)?;
     let currency = *partial.payment_info().currency();
     let exchange_rates = fetcher.fetch_for_line_items(currency, partial.line_items())?;
     let data_typst_compat = partial.to_typst(exchange_rates)?;

--- a/crates/core-invoice/src/models/data/data.rs
+++ b/crates/core-invoice/src/models/data/data.rs
@@ -1,8 +1,8 @@
 use crate::{
-    Cadence, CompanyInformation, DataFromDiskWithItemsOfKind, DataWithItemsPricedInSourceCurrency,
-    Error, ExpensedPeriods, HasSample, InvoiceInfoFull, InvoicedItems, Item,
-    LineItemsPricedInSourceCurrency, OutputPath, PaymentInformation, ProtoInvoiceInfo, Quantity,
-    Result, ServiceFees, TimeOff, ValidInput, calculate_invoice_number,
+    BankHolidays, Cadence, CompanyInformation, DataFromDiskWithItemsOfKind,
+    DataWithItemsPricedInSourceCurrency, Error, ExpensedPeriods, HasSample, InvoiceInfoFull,
+    InvoicedItems, Item, LineItemsPricedInSourceCurrency, OutputPath, PaymentInformation,
+    ProtoInvoiceInfo, Quantity, Result, ServiceFees, TimeOff, ValidInput, calculate_invoice_number,
     normalize_period_end_date_for_cadence, quantity_in_period,
 };
 use bon::Builder;
@@ -109,11 +109,17 @@ impl Data {
         target_period_end_date: &crate::Date,
         cadence: Cadence,
         time_off: &Option<TimeOff>,
+        bank_holidays: &BankHolidays,
     ) -> Result<Quantity> {
         let granularity = self.service_fees().rate().granularity();
         let periods_off = self.information().record_of_periods_off();
-        let quantity_in_period =
-            quantity_in_period(target_period_end_date, granularity, cadence, periods_off)?;
+        let quantity_in_period = quantity_in_period(
+            target_period_end_date,
+            granularity,
+            cadence,
+            periods_off,
+            bank_holidays,
+        )?;
         Ok(quantity_in_period - time_off.map(|d| *d).unwrap_or(Quantity::ZERO))
     }
 
@@ -130,11 +136,15 @@ impl Data {
     ///
     /// let data = Data::sample();
     /// let input = ValidInput::sample();
-    /// let partial = data.to_partial(input).unwrap();
+    /// let partial = data.to_partial(input, &BankHolidays::default()).unwrap();
     ///
     /// assert!(!partial.line_items().is_expenses());
     /// ```
-    pub fn to_partial(self, input: ValidInput) -> Result<DataWithItemsPricedInSourceCurrency> {
+    pub fn to_partial(
+        self,
+        input: ValidInput,
+        bank_holidays: &BankHolidays,
+    ) -> Result<DataWithItemsPricedInSourceCurrency> {
         let items = input.items();
         let cadence = *self.service_fees().cadence();
         let target_period_end_date = normalize_period_end_date_for_cadence(*input.date(), cadence)?;
@@ -200,8 +210,12 @@ impl Data {
                             }
                         }
 
-                        let quantity =
-                            self.billable_quantity(&target_period_end_date, cadence, time_off)?;
+                        let quantity = self.billable_quantity(
+                            &target_period_end_date,
+                            cadence,
+                            time_off,
+                            bank_holidays,
+                        )?;
                         let service = Item::builder()
                             .name(self.service_fees.name().clone())
                             .transaction_date(invoice_date)
@@ -321,7 +335,7 @@ mod tests {
             .items(InvoicedItems::Expenses)
             .date(crate::Date::sample())
             .build();
-        let partial = sut.to_partial(input).unwrap();
+        let partial = sut.to_partial(input, &BankHolidays::default()).unwrap();
         assert!(partial.line_items().is_expenses());
     }
 
@@ -350,7 +364,7 @@ mod tests {
             .date(crate::Date::sample())
             .build();
 
-        let result = sut.to_partial(input);
+        let result = sut.to_partial(input, &BankHolidays::default());
 
         if let Err(Error::InvalidGranularityForTimeOff {
             free_granularity,

--- a/crates/core-invoice/src/models/data/submodels/service_fees.rs
+++ b/crates/core-invoice/src/models/data/submodels/service_fees.rs
@@ -27,6 +27,17 @@ pub struct ServiceFees {
     /// How often you invoice, cannot be
     #[getset(get = "pub")]
     cadence: Cadence,
+
+    /// When `true`, public holidays in the vendor's country are deducted from
+    /// billable working days (for day- and hour-granularity rates). Defaults to
+    /// `false`, which preserves the prior behavior of counting every weekday.
+    ///
+    /// Holidays are looked up online (and cached to disk) using the vendor's
+    /// country; if the country cannot be resolved or the lookup fails, no
+    /// deduction is made.
+    #[getset(get = "pub")]
+    #[serde(default)]
+    off_on_bank_holidays: bool,
 }
 
 #[bon]
@@ -36,6 +47,7 @@ impl ServiceFees {
         name: impl AsRef<str>,
         rate: impl Into<Rate>,
         cadence: Cadence,
+        #[builder(default)] off_on_bank_holidays: bool,
     ) -> Result<Self, Error> {
         let rate = rate.into();
         if !cadence.validate(rate.granularity()) {
@@ -45,6 +57,7 @@ impl ServiceFees {
             name: name.as_ref().to_owned(),
             rate,
             cadence,
+            off_on_bank_holidays,
         })
     }
 }
@@ -98,5 +111,35 @@ mod tests {
     #[test]
     fn test_serde() {
         assert_ron_snapshot!(Sut::sample())
+    }
+
+    #[test]
+    fn off_on_bank_holidays_defaults_to_false() {
+        assert!(!Sut::sample().off_on_bank_holidays());
+    }
+
+    #[test]
+    fn builder_sets_off_on_bank_holidays() {
+        let fees = Sut::builder()
+            .name("Consulting".to_string())
+            .rate(crate::Rate::daily(dec!(100.0)))
+            .cadence(crate::Cadence::Monthly)
+            .off_on_bank_holidays(true)
+            .build()
+            .unwrap();
+        assert!(fees.off_on_bank_holidays());
+    }
+
+    #[test]
+    fn deserializes_legacy_ron_without_flag_as_false() {
+        // RON persisted before the field existed must still load (serde default).
+        let legacy = r#"(
+            name: "Agreed Consulting Service",
+            rate: Daily(UnitPrice(777.0)),
+            cadence: Monthly,
+        )"#;
+        let fees: Sut = crate::deserialize_ron_str(legacy).unwrap();
+        assert!(!fees.off_on_bank_holidays());
+        assert_eq!(fees.name(), "Agreed Consulting Service");
     }
 }

--- a/crates/core-invoice/src/models/data/submodels/snapshots/klirr_core_invoice__models__data__submodels__service_fees__tests__serde.snap
+++ b/crates/core-invoice/src/models/data/submodels/snapshots/klirr_core_invoice__models__data__submodels__service_fees__tests__serde.snap
@@ -6,4 +6,5 @@ ServiceFees(
   name: "Discreet Investigative Services",
   rate: Daily(UnitPrice(777.0)),
   cadence: Monthly,
+  off_on_bank_holidays: false,
 )

--- a/crates/core-invoice/src/models/mod.rs
+++ b/crates/core-invoice/src/models/mod.rs
@@ -25,8 +25,8 @@ pub use item_converted_into_target_currency::*;
 pub use klirr_foundation::HasSample;
 pub use klirr_foundation::OutputPath;
 pub use klirr_foundation::{
-    CompanyInformation, Cost, Date, Day, Decimal, HexColor, Month, MonthHalf, PostalAddress,
-    Quantity, Rate, RelativeTime, StreetAddress, UnitPrice, Vat, Year,
+    BankHolidays, CompanyInformation, Cost, CountryCode, Date, Day, Decimal, HexColor, Month,
+    MonthHalf, PostalAddress, Quantity, Rate, RelativeTime, StreetAddress, UnitPrice, Vat, Year,
 };
 pub use l10n::*;
 pub use layout::*;

--- a/crates/core-invoice/tests/typst_conversion.rs
+++ b/crates/core-invoice/tests/typst_conversion.rs
@@ -1,7 +1,7 @@
 use insta::assert_snapshot;
 use klirr_core_invoice::{
-    Currency, Data, Date, ExchangeRates, ExchangeRatesMap, HasSample, InvoicedItems, L10n,
-    LabeledField, Language, PreparedData, UnitPrice, ValidInput, Vat,
+    BankHolidays, Currency, Data, Date, ExchangeRates, ExchangeRatesMap, HasSample, InvoicedItems,
+    L10n, LabeledField, Language, PreparedData, UnitPrice, ValidInput, Vat,
 };
 use klirr_foundation::ToTypstFn;
 use rust_decimal::dec;
@@ -18,7 +18,7 @@ fn sample_exchange_rates() -> ExchangeRates {
 
 fn prepared_data_from(input: ValidInput) -> PreparedData {
     Data::sample()
-        .to_partial(input)
+        .to_partial(input, &BankHolidays::default())
         .unwrap()
         .to_typst(sample_exchange_rates())
         .unwrap()
@@ -77,7 +77,7 @@ fn data_services_with_payment_method_overrides_to_typst() {
         .expensed_periods(data.expensed_periods().clone())
         .build();
     let typst = data
-        .to_partial(input)
+        .to_partial(input, &BankHolidays::default())
         .unwrap()
         .to_typst(sample_exchange_rates())
         .unwrap()
@@ -109,7 +109,7 @@ fn data_services_with_vat_to_typst() {
         .expensed_periods(data.expensed_periods().clone())
         .build();
     let typst = data
-        .to_partial(input)
+        .to_partial(input, &BankHolidays::default())
         .unwrap()
         .to_typst(sample_exchange_rates())
         .unwrap()

--- a/crates/foundation/Cargo.toml
+++ b/crates/foundation/Cargo.toml
@@ -20,6 +20,7 @@ crypto = [
     "dep:zeroize",
 ]
 exchange-rates = ["dep:reqwest"]
+bank-holidays = ["dep:reqwest"]
 
 [dependencies]
 aes-gcm = { workspace = true, optional = true }

--- a/crates/foundation/src/bank_holidays.rs
+++ b/crates/foundation/src/bank_holidays.rs
@@ -1,0 +1,372 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use bon::Builder;
+use indexmap::{IndexMap, IndexSet};
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BankHolidays, CountryCode, Date, Year, data_dir, deserialize_contents_of_ron,
+    path_to_ron_file_with_base, save_to_disk,
+};
+
+pub type Result<T, E = BankHolidaysError> = std::result::Result<T, E>;
+
+/// Base URL of the [Nager.Date][api] public holiday API.
+///
+/// Full endpoint: `{NAGER_API}/{year}/{countryCode}`.
+///
+/// [api]: https://date.nager.at/
+const NAGER_API: &str = "https://date.nager.at/api/v3/PublicHolidays";
+const CACHED_HOLIDAYS_FILE_NAME: &str = "cached_holidays";
+/// Nager.Date holiday `type` denoting a nationwide public holiday — the only
+/// type we deduct from billable days.
+const HOLIDAY_TYPE_PUBLIC: &str = "Public";
+
+/// Error fetching or parsing bank holidays from the holiday API.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BankHolidaysError {
+    /// The HTTP request to the holiday API failed.
+    NetworkError {
+        /// Underlying transport error description.
+        underlying: String,
+    },
+    /// The holiday API response could not be parsed.
+    ParseError {
+        /// Underlying parse error description.
+        underlying: String,
+    },
+}
+
+impl BankHolidaysError {
+    pub fn parse_error(underlying: impl std::fmt::Display) -> Self {
+        Self::ParseError {
+            underlying: underlying.to_string(),
+        }
+    }
+
+    pub fn network_error(underlying: impl std::fmt::Display) -> Self {
+        Self::NetworkError {
+            underlying: underlying.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for BankHolidaysError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NetworkError { underlying } => {
+                write!(
+                    f,
+                    "Failed to fetch bank holidays from API, because: {underlying}"
+                )
+            }
+            Self::ParseError { underlying } => {
+                write!(
+                    f,
+                    "Failed to parse bank holidays response, because: {underlying}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for BankHolidaysError {}
+
+/// Abstraction over an HTTP response that can be deserialized as JSON, allowing
+/// tests to inject mock responses without performing network requests.
+pub trait DeserializableHolidaysResponse {
+    fn json<T: serde::de::DeserializeOwned>(self) -> Result<T>;
+}
+
+impl DeserializableHolidaysResponse for reqwest::blocking::Response {
+    fn json<T: serde::de::DeserializeOwned>(self) -> Result<T> {
+        self.json().map_err(BankHolidaysError::parse_error)
+    }
+}
+
+/// A single holiday entry as returned by the Nager.Date API. Only the fields we
+/// need are modelled; the rest are ignored during deserialization.
+#[derive(Debug, Clone, Deserialize)]
+struct NagerHoliday {
+    /// ISO date, e.g. `"2026-06-06"`.
+    date: String,
+    /// Holiday categories, e.g. `["Public"]`.
+    types: Vec<String>,
+}
+
+/// Builds the Nager.Date URL for a given year and country.
+fn format_url(year: i32, country: &CountryCode) -> String {
+    format!("{NAGER_API}/{year}/{}", country.as_str())
+}
+
+/// Keeps only nationwide public holidays and converts them into [`BankHolidays`].
+fn parse_public_holidays(raw: Vec<NagerHoliday>) -> Result<BankHolidays> {
+    let mut dates = IndexSet::new();
+    for holiday in raw {
+        let is_public = holiday
+            .types
+            .iter()
+            .any(|holiday_type| holiday_type == HOLIDAY_TYPE_PUBLIC);
+        if !is_public {
+            continue;
+        }
+        let date = Date::from_str(&holiday.date).map_err(BankHolidaysError::parse_error)?;
+        dates.insert(date);
+    }
+    Ok(BankHolidays::from(dates))
+}
+
+/// Fetches public holidays for a year and country using a custom fetcher
+/// closure. The closure receives the request URL and returns a deserializable
+/// response.
+pub fn get_bank_holidays_with_fetcher<T: DeserializableHolidaysResponse>(
+    year: i32,
+    country: &CountryCode,
+    fetcher: impl Fn(String) -> Result<T>,
+) -> Result<BankHolidays> {
+    debug!("Fetching bank holidays for {} @ {year}.", country.as_str());
+    let raw = fetcher(format_url(year, country))?.json::<Vec<NagerHoliday>>()?;
+    parse_public_holidays(raw)
+}
+
+/// Fetches public holidays via a blocking `reqwest` request.
+pub fn get_bank_holidays_with_reqwest(year: i32, country: &CountryCode) -> Result<BankHolidays> {
+    get_bank_holidays_with_fetcher(year, country, |url| {
+        reqwest::blocking::get(&url).map_err(BankHolidaysError::network_error)
+    })
+}
+
+type FetchedNew = bool;
+
+/// On-disk cache of bank holidays, keyed by ISO country code then year. Mirrors
+/// the exchange-rate cache so holidays fetched once are reused offline.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+struct CachedHolidays(IndexMap<String, IndexMap<i32, BankHolidays>>);
+
+impl CachedHolidays {
+    fn holidays_for_country(&mut self, country: &CountryCode) -> &mut IndexMap<i32, BankHolidays> {
+        self.0.entry(country.as_str().to_owned()).or_default()
+    }
+
+    fn load_else_fetch(
+        &mut self,
+        country: &CountryCode,
+        year: i32,
+        fetch: impl FnOnce(i32, &CountryCode) -> Result<BankHolidays>,
+    ) -> Result<(BankHolidays, FetchedNew)> {
+        let by_year = self.holidays_for_country(country);
+        if let Some(holidays) = by_year.get(&year) {
+            Ok((holidays.clone(), false))
+        } else {
+            let holidays = fetch(year, country)?;
+            by_year.insert(year, holidays.clone());
+            Ok((holidays, true))
+        }
+    }
+}
+
+/// Fetches bank holidays for the vendor's country, caching results to disk.
+#[derive(Builder)]
+pub struct BankHolidaysFetcher<T = ()> {
+    path_to_cache: PathBuf,
+    #[allow(dead_code)]
+    extra: T,
+}
+
+impl Default for BankHolidaysFetcher {
+    fn default() -> Self {
+        Self {
+            path_to_cache: data_dir(),
+            extra: (),
+        }
+    }
+}
+
+impl<T> BankHolidaysFetcher<T> {
+    fn path(&self) -> PathBuf {
+        path_to_ron_file_with_base(&self.path_to_cache, CACHED_HOLIDAYS_FILE_NAME)
+    }
+
+    fn load_cache(&self) -> Result<CachedHolidays> {
+        deserialize_contents_of_ron(self.path())
+            .map_err(|error| BankHolidaysError::parse_error(format!("{error:?}")))
+    }
+
+    fn save_cache(&self, cache: &CachedHolidays) -> Result<()> {
+        save_to_disk(cache, self.path())
+            .map(|_| ())
+            .map_err(|error| BankHolidaysError::parse_error(format!("{error:?}")))
+    }
+
+    fn load_cache_else_new(&self) -> CachedHolidays {
+        self.load_cache().unwrap_or_else(|_| {
+            debug!("No cached bank holidays found, fetching anew.");
+            CachedHolidays::default()
+        })
+    }
+
+    fn update_cache_if_needed(&self, cache: &CachedHolidays, fetched_new: bool) {
+        if !fetched_new {
+            debug!("ℹ️ No new bank holidays fetched, used only cached holidays.");
+            return;
+        }
+        match self.save_cache(cache) {
+            Ok(_) => debug!("✅ Cached bank holidays updated."),
+            Err(e) => {
+                warn!("Failed to cache bank holidays: {e} (this has no affect on PDF generation.)")
+            }
+        }
+    }
+
+    /// Returns the public holidays for `country` in `year`, using the on-disk
+    /// cache when available and fetching from the API on a miss.
+    pub fn holidays_for(&self, country: &CountryCode, year: Year) -> Result<BankHolidays> {
+        let year = i32::from(*year);
+        let mut cache = self.load_cache_else_new();
+        let (holidays, fetched_new) =
+            cache.load_else_fetch(country, year, get_bank_holidays_with_reqwest)?;
+        self.update_cache_if_needed(&cache, fetched_new);
+        Ok(holidays)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::{TempDir, tempdir};
+    use test_log::test;
+
+    fn temp_fetcher(tempdir: &TempDir) -> BankHolidaysFetcher {
+        BankHolidaysFetcher::builder()
+            .path_to_cache(tempdir.path().to_path_buf())
+            .extra(())
+            .build()
+    }
+
+    fn sweden() -> CountryCode {
+        CountryCode::new("SE").unwrap()
+    }
+
+    struct MockResponse(&'static str);
+    impl DeserializableHolidaysResponse for MockResponse {
+        fn json<T: serde::de::DeserializeOwned>(self) -> Result<T> {
+            serde_json::from_str(self.0).map_err(BankHolidaysError::parse_error)
+        }
+    }
+
+    #[test]
+    fn test_format_url() {
+        let url = format_url(2026, &sweden());
+        assert_eq!(url, "https://date.nager.at/api/v3/PublicHolidays/2026/SE");
+    }
+
+    #[test]
+    fn parses_only_public_holidays_from_mock() {
+        let body = r#"[
+            {"date":"2026-01-01","types":["Public"]},
+            {"date":"2026-06-06","types":["Public","Bank"]},
+            {"date":"2026-12-24","types":["Observance"]}
+        ]"#;
+        let holidays = get_bank_holidays_with_fetcher(2026, &sweden(), |_url| {
+            Ok::<MockResponse, BankHolidaysError>(MockResponse(body))
+        })
+        .unwrap();
+        assert_eq!(holidays.len(), 2);
+        assert!(holidays.contains(&Date::from_str("2026-01-01").unwrap()));
+        assert!(holidays.contains(&Date::from_str("2026-06-06").unwrap()));
+        assert!(!holidays.contains(&Date::from_str("2026-12-24").unwrap()));
+    }
+
+    #[test]
+    fn parse_error_on_bad_date() {
+        let body = r#"[{"date":"not-a-date","types":["Public"]}]"#;
+        let result = get_bank_holidays_with_fetcher(2026, &sweden(), |_url| {
+            Ok::<MockResponse, BankHolidaysError>(MockResponse(body))
+        });
+        assert!(matches!(result, Err(BankHolidaysError::ParseError { .. })));
+    }
+
+    #[test]
+    fn fetcher_uses_custom_cache_dir() {
+        let tempdir = tempdir().unwrap();
+        let fetcher = temp_fetcher(&tempdir);
+        assert!(fetcher.path().ends_with("cached_holidays.ron"));
+    }
+
+    #[test]
+    fn cache_hit_avoids_fetch() {
+        let year = 2026;
+        let holidays = BankHolidays::new([Date::from_str("2026-06-06").unwrap()]);
+        let mut cache = CachedHolidays::default();
+        cache
+            .holidays_for_country(&sweden())
+            .insert(year, holidays.clone());
+
+        let (loaded, fetched_new) = cache
+            .load_else_fetch(&sweden(), year, |_year, _country| {
+                unreachable!("must not fetch on cache hit")
+            })
+            .unwrap();
+
+        assert!(!fetched_new);
+        assert_eq!(loaded, holidays);
+    }
+
+    #[test]
+    fn cache_miss_fetches_and_inserts() {
+        let year = 2026;
+        let holidays = BankHolidays::new([Date::from_str("2026-06-06").unwrap()]);
+        let mut cache = CachedHolidays::default();
+
+        let (loaded, fetched_new) = cache
+            .load_else_fetch(&sweden(), year, |_year, _country| Ok(holidays.clone()))
+            .unwrap();
+
+        assert!(fetched_new);
+        assert_eq!(loaded, holidays);
+        // Second lookup is now a hit.
+        let (_, fetched_new_again) = cache
+            .load_else_fetch(&sweden(), year, |_year, _country| {
+                unreachable!("second lookup must hit cache")
+            })
+            .unwrap();
+        assert!(!fetched_new_again);
+    }
+
+    #[test]
+    fn if_fetched_new_is_false_cache_is_unchanged() {
+        let tempdir = tempdir().unwrap();
+        let fetcher = temp_fetcher(&tempdir);
+        fetcher.update_cache_if_needed(&CachedHolidays::default(), false);
+        assert!(
+            !fetcher.path().exists(),
+            "Cache file should not exist when no new holidays were fetched."
+        );
+    }
+
+    #[test]
+    fn if_fetched_new_is_true_cache_is_written() {
+        let tempdir = tempdir().unwrap();
+        let fetcher = temp_fetcher(&tempdir);
+        let mut cache = CachedHolidays::default();
+        cache.holidays_for_country(&sweden()).insert(
+            2026,
+            BankHolidays::new([Date::from_str("2026-06-06").unwrap()]),
+        );
+
+        fetcher.update_cache_if_needed(&cache, true);
+
+        let loaded: CachedHolidays = deserialize_contents_of_ron(fetcher.path()).unwrap();
+        assert_eq!(loaded, cache);
+    }
+
+    #[test]
+    fn gibberish_cache_is_reset() {
+        let tempdir = tempdir().unwrap();
+        let fetcher = temp_fetcher(&tempdir);
+        std::fs::write(fetcher.path(), "gibberish").unwrap();
+        assert_eq!(fetcher.load_cache_else_new(), CachedHolidays::default());
+    }
+}

--- a/crates/foundation/src/calendar_logic.rs
+++ b/crates/foundation/src/calendar_logic.rs
@@ -1,7 +1,9 @@
 use std::str::FromStr;
 use std::{cmp::Ordering, ops::Mul};
 
-use crate::{Cadence, Date, Day, Granularity, ModelError, Month, Quantity, RelativeTime, Year};
+use crate::{
+    BankHolidays, Cadence, Date, Day, Granularity, ModelError, Month, Quantity, RelativeTime, Year,
+};
 use chrono::{Datelike, NaiveDate, Weekday};
 use indexmap::IndexSet;
 use thiserror::Error as ThisError;
@@ -370,7 +372,14 @@ fn period_bounds(period_end: Date, cadence: Cadence) -> CalendarResult<(Date, Da
     Ok((start, period_end))
 }
 
-fn working_days_between(start: Date, end: Date) -> CalendarResult<Quantity> {
+/// Counts weekdays (Mon–Fri) in the inclusive range `[start, end]`, excluding
+/// any date in `bank_holidays`. A holiday that already falls on a weekend is a
+/// no-op, so it is never double-counted.
+fn working_days_between(
+    start: Date,
+    end: Date,
+    bank_holidays: &BankHolidays,
+) -> CalendarResult<Quantity> {
     let start = NaiveDate::from_ymd_opt(
         **start.year() as i32,
         **start.month() as u32,
@@ -389,14 +398,16 @@ fn working_days_between(start: Date, end: Date) -> CalendarResult<Quantity> {
         underlying: "Invalid end date".to_owned(),
     })?;
 
+    let holidays = bank_holidays.as_naive_dates();
     let mut current = start;
     let mut working_days = 0;
     while current <= end {
-        match current.weekday() {
-            Weekday::Mon | Weekday::Tue | Weekday::Wed | Weekday::Thu | Weekday::Fri => {
-                working_days += 1;
-            }
-            Weekday::Sat | Weekday::Sun => {}
+        let is_weekday = matches!(
+            current.weekday(),
+            Weekday::Mon | Weekday::Tue | Weekday::Wed | Weekday::Thu | Weekday::Fri
+        );
+        if is_weekday && !holidays.contains(&current) {
+            working_days += 1;
         }
         current = current.succ_opt().ok_or(CalendarError::InvalidDate {
             underlying: "Failed to advance day".to_owned(),
@@ -406,12 +417,20 @@ fn working_days_between(start: Date, end: Date) -> CalendarResult<Quantity> {
     Ok(Quantity::from(working_days))
 }
 
-fn working_days_in_period(period_end: Date, cadence: Cadence) -> CalendarResult<Quantity> {
+fn working_days_in_period(
+    period_end: Date,
+    cadence: Cadence,
+    bank_holidays: &BankHolidays,
+) -> CalendarResult<Quantity> {
     let (start, end) = period_bounds(period_end, cadence)?;
-    working_days_between(start, end)
+    working_days_between(start, end, bank_holidays)
 }
 
 /// Calculates billable quantity for a period-end date and cadence.
+///
+/// `bank_holidays` are deducted from billable working days for day- and
+/// hour-granularity rates only; monthly/fortnightly fixed rates are unaffected.
+/// Pass [`BankHolidays::default`] (empty) to count every weekday.
 ///
 /// # Examples
 /// ```
@@ -426,6 +445,7 @@ fn working_days_in_period(period_end: Date, cadence: Cadence) -> CalendarResult<
 ///     Granularity::Day,
 ///     Cadence::Monthly,
 ///     &IndexSet::default(),
+///     &BankHolidays::default(),
 /// )
 /// .unwrap();
 ///
@@ -436,6 +456,7 @@ pub fn quantity_in_period(
     granularity: Granularity,
     cadence: Cadence,
     record_of_periods_off: &IndexSet<Date>,
+    bank_holidays: &BankHolidays,
 ) -> CalendarResult<Quantity> {
     let target_date = period_end_for_cadence(*target_date, cadence)?;
 
@@ -458,10 +479,12 @@ pub fn quantity_in_period(
             Cadence::Monthly => Ok(Quantity::TWO),
             Cadence::BiWeekly => Ok(Quantity::ONE),
         },
-        Granularity::Day => working_days_in_period(target_date, cadence),
-        Granularity::Hour => {
-            Ok(Quantity::EIGHT.mul(*working_days_in_period(target_date, cadence)?))
-        }
+        Granularity::Day => working_days_in_period(target_date, cadence, bank_holidays),
+        Granularity::Hour => Ok(Quantity::EIGHT.mul(*working_days_in_period(
+            target_date,
+            cadence,
+            bank_holidays,
+        )?)),
     }
 }
 
@@ -724,13 +747,65 @@ mod tests {
         assert_eq!(end_second, d("2025-05-31"));
     }
 
+    fn no_holidays() -> BankHolidays {
+        BankHolidays::default()
+    }
+
     #[test]
     fn working_days_between_counts_weekdays_only() {
-        let weekends = working_days_between(d("2025-05-17"), d("2025-05-18")).unwrap();
+        let weekends =
+            working_days_between(d("2025-05-17"), d("2025-05-18"), &no_holidays()).unwrap();
         assert_eq!(*weekends, dec!(0));
 
-        let weekday = working_days_between(d("2025-05-19"), d("2025-05-19")).unwrap();
+        let weekday =
+            working_days_between(d("2025-05-19"), d("2025-05-19"), &no_holidays()).unwrap();
         assert_eq!(*weekday, dec!(1));
+    }
+
+    #[test]
+    fn working_days_between_excludes_bank_holiday() {
+        // 2025-05-19 .. 2025-05-23 is Mon..Fri => 5 working days.
+        let span = (d("2025-05-19"), d("2025-05-23"));
+        let full = working_days_between(span.0, span.1, &no_holidays()).unwrap();
+        assert_eq!(*full, dec!(5));
+
+        // Marking the Wednesday as a holiday removes exactly one working day.
+        let holidays = BankHolidays::new([d("2025-05-21")]);
+        let reduced = working_days_between(span.0, span.1, &holidays).unwrap();
+        assert_eq!(*reduced, dec!(4));
+    }
+
+    #[test]
+    fn working_days_between_holiday_on_weekend_is_noop() {
+        // 2025-05-17 is a Saturday — marking it as a holiday changes nothing.
+        let span = (d("2025-05-19"), d("2025-05-23"));
+        let holidays = BankHolidays::new([d("2025-05-17")]);
+        let count = working_days_between(span.0, span.1, &holidays).unwrap();
+        assert_eq!(*count, dec!(5));
+    }
+
+    #[test]
+    fn quantity_in_period_deducts_bank_holidays_for_hours() {
+        let target = d("2025-05-31");
+        let days_off_one = BankHolidays::new([d("2025-05-21")]);
+        let hours_full = quantity_in_period(
+            &target,
+            Granularity::Hour,
+            Cadence::Monthly,
+            &IndexSet::default(),
+            &no_holidays(),
+        )
+        .unwrap();
+        let hours_reduced = quantity_in_period(
+            &target,
+            Granularity::Hour,
+            Cadence::Monthly,
+            &IndexSet::default(),
+            &days_off_one,
+        )
+        .unwrap();
+        // One holiday removes one working day == 8 hours.
+        assert_eq!(*hours_full - *hours_reduced, dec!(8));
     }
 
     #[test]
@@ -741,6 +816,7 @@ mod tests {
             Granularity::Day,
             Cadence::Monthly,
             &IndexSet::default(),
+            &no_holidays(),
         )
         .unwrap();
         let fortnight = quantity_in_period(
@@ -748,6 +824,7 @@ mod tests {
             Granularity::Day,
             Cadence::BiWeekly,
             &IndexSet::default(),
+            &no_holidays(),
         )
         .unwrap();
         assert!(fortnight < monthly);
@@ -761,6 +838,7 @@ mod tests {
                 Granularity::Month,
                 Cadence::Monthly,
                 &IndexSet::default(),
+                &no_holidays(),
             )
             .unwrap(),
             Quantity::ONE
@@ -771,6 +849,7 @@ mod tests {
                 Granularity::Fortnight,
                 Cadence::Monthly,
                 &IndexSet::default(),
+                &no_holidays(),
             )
             .unwrap(),
             Quantity::TWO
@@ -781,6 +860,7 @@ mod tests {
                 Granularity::Fortnight,
                 Cadence::BiWeekly,
                 &IndexSet::default(),
+                &no_holidays(),
             )
             .unwrap(),
             Quantity::ONE
@@ -795,6 +875,7 @@ mod tests {
             Granularity::Day,
             Cadence::BiWeekly,
             &IndexSet::default(),
+            &no_holidays(),
         )
         .unwrap();
         let hours = quantity_in_period(
@@ -802,6 +883,7 @@ mod tests {
             Granularity::Hour,
             Cadence::BiWeekly,
             &IndexSet::default(),
+            &no_holidays(),
         )
         .unwrap();
         assert_eq!(hours, Quantity::EIGHT.mul(*days));
@@ -811,7 +893,13 @@ mod tests {
     fn quantity_in_period_fails_when_target_is_in_periods_off() {
         let target = d("2025-05-31");
         let periods_off = periods_off([target]);
-        let result = quantity_in_period(&target, Granularity::Day, Cadence::Monthly, &periods_off);
+        let result = quantity_in_period(
+            &target,
+            Granularity::Day,
+            Cadence::Monthly,
+            &periods_off,
+            &no_holidays(),
+        );
         assert_eq!(
             result.unwrap_err(),
             CalendarError::TargetPeriodMustNotBeInRecordOfPeriodsOff {
@@ -828,6 +916,7 @@ mod tests {
             Granularity::Month,
             Cadence::BiWeekly,
             &IndexSet::default(),
+            &no_holidays(),
         );
         assert_eq!(
             result.unwrap_err(),

--- a/crates/foundation/src/lib.rs
+++ b/crates/foundation/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bank-holidays")]
+mod bank_holidays;
 mod calendar_logic;
 mod document;
 #[cfg(feature = "crypto")]
@@ -13,6 +15,11 @@ mod sample;
 mod traits;
 mod typst_layouts;
 
+#[cfg(feature = "bank-holidays")]
+pub use crate::bank_holidays::{
+    BankHolidaysError, BankHolidaysFetcher, DeserializableHolidaysResponse,
+    get_bank_holidays_with_fetcher, get_bank_holidays_with_reqwest,
+};
 pub use crate::calendar_logic::{
     CalendarError, CalendarResult, calculate_period_number, normalize_period_end_date_for_cadence,
     parse_period_label_for_cadence, period_end_from_relative_time, quantity_in_period,
@@ -33,10 +40,10 @@ pub use crate::exchange_rates::{
 pub use crate::fs_utils::{create_folder_if_needed, create_folder_to_parent_of_path_if_needed};
 pub use crate::functional::{ResultExt, curry1, curry2};
 pub use crate::models::{
-    AbstractNamedPdf, Cadence, CompanyInformation, Cost, Currency, Date, Day, Decimal, DueInDays,
-    FontIdentifier, FontWeight, Granularity, HexColor, ModelError, ModelResult, Month, MonthHalf,
-    OutputPath, PathAndName, Pdf, PostalAddress, Quantity, Rate, RelativeTime, StreetAddress,
-    UnitPrice, Vat, Year, save_pdf,
+    AbstractNamedPdf, BankHolidays, Cadence, CompanyInformation, Cost, CountryCode, Currency, Date,
+    Day, Decimal, DueInDays, FontIdentifier, FontWeight, Granularity, HexColor, InvalidCountryCode,
+    ModelError, ModelResult, Month, MonthHalf, OutputPath, PathAndName, Pdf, PostalAddress,
+    Quantity, Rate, RelativeTime, StreetAddress, UnitPrice, Vat, Year, save_pdf,
 };
 pub use crate::ron::{
     RonError, deserialize_contents_of_ron, deserialize_ron_str, path_to_ron_file_with_base,

--- a/crates/foundation/src/models/bank_holidays.rs
+++ b/crates/foundation/src/models/bank_holidays.rs
@@ -1,0 +1,104 @@
+use std::collections::HashSet;
+
+use chrono::NaiveDate;
+use derive_more::Deref;
+use derive_more::From;
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+
+use crate::{Date, HasSample};
+
+/// A set of public/bank holiday dates for a single country and year.
+///
+/// These dates are deducted from billable working days when a vendor has opted
+/// to be off on bank holidays (see
+/// `klirr_core_invoice::ServiceFees::off_on_bank_holidays`). An empty set means
+/// "no holidays to deduct" — the safe default that preserves prior behavior.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Deref, From)]
+pub struct BankHolidays(IndexSet<Date>);
+
+impl BankHolidays {
+    /// Creates a [`BankHolidays`] set from an iterator of dates.
+    pub fn new(dates: impl IntoIterator<Item = Date>) -> Self {
+        Self(IndexSet::from_iter(dates))
+    }
+
+    /// Returns the holidays as a [`HashSet`] of [`NaiveDate`] for O(1) lookup
+    /// while iterating days in a period.
+    ///
+    /// # Examples
+    /// ```
+    /// extern crate klirr_foundation;
+    /// use klirr_foundation::*;
+    ///
+    /// let holidays = BankHolidays::new(["2025-06-06".parse::<Date>().unwrap()]);
+    /// let naive = holidays.as_naive_dates();
+    /// assert_eq!(naive.len(), 1);
+    /// ```
+    pub fn as_naive_dates(&self) -> HashSet<NaiveDate> {
+        self.0
+            .iter()
+            .filter_map(|date| {
+                NaiveDate::from_ymd_opt(
+                    **date.year() as i32,
+                    **date.month() as u32,
+                    **date.day() as u32,
+                )
+            })
+            .collect()
+    }
+}
+
+impl HasSample for BankHolidays {
+    fn sample() -> Self {
+        // Swedish national day, 2025-06-06 (a Friday).
+        Self::new(["2025-06-06".parse::<Date>().expect("valid sample date")])
+    }
+
+    fn sample_other() -> Self {
+        // US Independence Day, 2025-07-04 (a Friday).
+        Self::new(["2025-07-04".parse::<Date>().expect("valid sample date")])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    type Sut = BankHolidays;
+
+    #[test]
+    fn equality() {
+        assert_eq!(Sut::sample(), Sut::sample());
+        assert_eq!(Sut::sample_other(), Sut::sample_other());
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(Sut::sample(), Sut::sample_other());
+    }
+
+    #[test]
+    fn default_is_empty() {
+        assert!(Sut::default().is_empty());
+    }
+
+    #[test]
+    fn new_deduplicates() {
+        let date = "2025-06-06".parse::<Date>().unwrap();
+        let holidays = Sut::new([date, date]);
+        assert_eq!(holidays.len(), 1);
+    }
+
+    #[test]
+    fn as_naive_dates_roundtrips() {
+        let holidays = Sut::new([
+            "2025-06-06".parse::<Date>().unwrap(),
+            "2025-12-25".parse::<Date>().unwrap(),
+        ]);
+        let naive = holidays.as_naive_dates();
+        assert!(naive.contains(&NaiveDate::from_ymd_opt(2025, 6, 6).unwrap()));
+        assert!(naive.contains(&NaiveDate::from_ymd_opt(2025, 12, 25).unwrap()));
+    }
+}

--- a/crates/foundation/src/models/country_code.rs
+++ b/crates/foundation/src/models/country_code.rs
@@ -1,0 +1,266 @@
+use std::ops::Deref;
+
+use derive_more::Display;
+
+/// Number of characters in an ISO 3166-1 alpha-2 country code, e.g. `SE`.
+const COUNTRY_CODE_LEN: usize = 2;
+
+/// An [ISO 3166-1 alpha-2][iso] country code, e.g. `SE` for Sweden, `GB` for
+/// the United Kingdom or `US` for the United States.
+///
+/// Always exactly two ASCII uppercase letters. Used to look up public holidays
+/// for the country of a vendor.
+///
+/// [iso]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+#[derive(Clone, Debug, Display, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CountryCode(String);
+
+/// Error returned when constructing a [`CountryCode`] from an invalid string.
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
+#[display(
+    "Invalid ISO 3166-1 alpha-2 country code: '{invalid}', expected exactly two ASCII letters."
+)]
+pub struct InvalidCountryCode {
+    /// The offending input string.
+    pub invalid: String,
+}
+
+impl std::error::Error for InvalidCountryCode {}
+
+impl CountryCode {
+    /// Constructs a [`CountryCode`] from a known-valid static code.
+    ///
+    /// Used internally by [`Self::from_country_name`] where the codes come from
+    /// a curated table and are guaranteed valid.
+    fn from_static(code: &'static str) -> Self {
+        Self::new(code).expect("Curated country codes must be valid")
+    }
+
+    /// Constructs a [`CountryCode`], validating that `code` is exactly two ASCII
+    /// letters. The code is upper-cased.
+    ///
+    /// # Errors
+    /// Returns [`InvalidCountryCode`] if `code` is not two ASCII letters.
+    ///
+    /// # Examples
+    /// ```
+    /// extern crate klirr_foundation;
+    /// use klirr_foundation::*;
+    ///
+    /// assert_eq!(CountryCode::new("se").unwrap().as_str(), "SE");
+    /// assert!(CountryCode::new("Sweden").is_err());
+    /// assert!(CountryCode::new("S1").is_err());
+    /// ```
+    pub fn new(code: impl AsRef<str>) -> Result<Self, InvalidCountryCode> {
+        let code = code.as_ref();
+        let is_valid =
+            code.len() == COUNTRY_CODE_LEN && code.chars().all(|c| c.is_ascii_alphabetic());
+        if is_valid {
+            Ok(Self(code.to_ascii_uppercase()))
+        } else {
+            Err(InvalidCountryCode {
+                invalid: code.to_owned(),
+            })
+        }
+    }
+
+    /// Returns the two-letter code, e.g. `"SE"`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Resolves a free-text country name (as stored in a postal address) into an
+    /// ISO 3166-1 alpha-2 code, handling common aliases (`"England"`, `"UK"` →
+    /// `GB`; `"USA"` → `US`; `"Sverige"` → `SE`). The two-letter code itself is
+    /// also accepted.
+    ///
+    /// Returns `None` for unrecognized names — callers should degrade gracefully
+    /// (skip holiday deduction) rather than fail.
+    ///
+    /// # Examples
+    /// ```
+    /// extern crate klirr_foundation;
+    /// use klirr_foundation::*;
+    ///
+    /// assert_eq!(CountryCode::from_country_name("Sweden").unwrap().as_str(), "SE");
+    /// assert_eq!(CountryCode::from_country_name("England").unwrap().as_str(), "GB");
+    /// assert_eq!(CountryCode::from_country_name("  united states of america ").unwrap().as_str(), "US");
+    /// assert_eq!(CountryCode::from_country_name("SE").unwrap().as_str(), "SE");
+    /// assert!(CountryCode::from_country_name("Atlantis").is_none());
+    /// ```
+    pub fn from_country_name(name: impl AsRef<str>) -> Option<Self> {
+        let normalized = name.as_ref().trim().to_ascii_lowercase();
+        code_for_normalized_country_name(&normalized).map(Self::from_static)
+    }
+}
+
+impl Deref for CountryCode {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for CountryCode {
+    type Err = InvalidCountryCode;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+/// Maps a normalized (trimmed, lower-cased) country name or two-letter code to
+/// its ISO 3166-1 alpha-2 code.
+///
+/// This is intentionally a flat lookup table — it mirrors the breadth of the
+/// holiday API's supported countries and is expected to grow by simple
+/// extension. Names listed here cover the most common spellings and aliases; a
+/// missing entry simply means no holiday deduction for that vendor country.
+fn code_for_normalized_country_name(normalized: &str) -> Option<&'static str> {
+    let code = match normalized {
+        // Nordics
+        "sweden" | "sverige" | "se" => "SE",
+        "norway" | "norge" | "no" => "NO",
+        "denmark" | "danmark" | "dk" => "DK",
+        "finland" | "suomi" | "fi" => "FI",
+        "iceland" | "ísland" | "island" | "is" => "IS",
+        // United Kingdom & constituent countries
+        "united kingdom" | "uk" | "u.k." | "great britain" | "britain" | "england" | "scotland"
+        | "wales" | "northern ireland" | "gb" => "GB",
+        "ireland" | "éire" | "eire" | "ie" => "IE",
+        // North America
+        "united states"
+        | "united states of america"
+        | "usa"
+        | "u.s.a."
+        | "u.s."
+        | "america"
+        | "us" => "US",
+        "canada" | "ca" => "CA",
+        "mexico" | "méxico" | "mx" => "MX",
+        // Western & Central Europe
+        "germany" | "deutschland" | "de" => "DE",
+        "france" | "fr" => "FR",
+        "spain" | "españa" | "espana" | "es" => "ES",
+        "portugal" | "pt" => "PT",
+        "italy" | "italia" | "it" => "IT",
+        "netherlands" | "the netherlands" | "holland" | "nederland" | "nl" => "NL",
+        "belgium" | "belgië" | "belgique" | "be" => "BE",
+        "luxembourg" | "lu" => "LU",
+        "switzerland" | "schweiz" | "suisse" | "ch" => "CH",
+        "austria" | "österreich" | "osterreich" | "at" => "AT",
+        "poland" | "polska" | "pl" => "PL",
+        "czechia" | "czech republic" | "cz" => "CZ",
+        "slovakia" | "sk" => "SK",
+        "hungary" | "hu" => "HU",
+        "greece" | "gr" => "GR",
+        "romania" | "ro" => "RO",
+        "bulgaria" | "bg" => "BG",
+        "croatia" | "hr" => "HR",
+        "slovenia" | "si" => "SI",
+        "estonia" | "ee" => "EE",
+        "latvia" | "lv" => "LV",
+        "lithuania" | "lt" => "LT",
+        // Rest of the world (common business locales)
+        "australia" | "au" => "AU",
+        "new zealand" | "nz" => "NZ",
+        "japan" | "jp" => "JP",
+        "south korea" | "korea" | "kr" => "KR",
+        "china" | "cn" => "CN",
+        "india" | "in" => "IN",
+        "singapore" | "sg" => "SG",
+        "hong kong" | "hk" => "HK",
+        "brazil" | "brasil" | "br" => "BR",
+        "argentina" | "ar" => "AR",
+        "south africa" | "za" => "ZA",
+        _ => return None,
+    };
+    Some(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use test_log::test;
+
+    type Sut = CountryCode;
+
+    #[test]
+    fn new_uppercases() {
+        assert_eq!(Sut::new("se").unwrap().as_str(), "SE");
+        assert_eq!(Sut::new("Gb").unwrap().as_str(), "GB");
+    }
+
+    #[test]
+    fn new_rejects_invalid() {
+        assert!(Sut::new("Sweden").is_err());
+        assert!(Sut::new("S").is_err());
+        assert!(Sut::new("S1").is_err());
+        assert!(Sut::new("").is_err());
+    }
+
+    #[test]
+    fn from_str_delegates_to_new() {
+        assert_eq!(Sut::from_str("us").unwrap().as_str(), "US");
+        assert!(Sut::from_str("nope-nope").is_err());
+    }
+
+    #[test]
+    fn resolves_sweden_variants() {
+        for name in ["Sweden", "sverige", "SE", " se ", "SWEDEN"] {
+            assert_eq!(
+                Sut::from_country_name(name).unwrap().as_str(),
+                "SE",
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_uk_aliases() {
+        for name in [
+            "United Kingdom",
+            "UK",
+            "England",
+            "Scotland",
+            "Great Britain",
+            "GB",
+        ] {
+            assert_eq!(
+                Sut::from_country_name(name).unwrap().as_str(),
+                "GB",
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_us_aliases() {
+        for name in ["United States", "USA", "U.S.A.", "America", "US"] {
+            assert_eq!(
+                Sut::from_country_name(name).unwrap().as_str(),
+                "US",
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_country_is_none() {
+        assert!(Sut::from_country_name("Atlantis").is_none());
+        assert!(Sut::from_country_name("").is_none());
+    }
+
+    #[test]
+    fn display_equals_as_str() {
+        let code = Sut::new("de").unwrap();
+        assert_eq!(code.to_string(), code.as_str());
+        assert_eq!(&*code, "DE");
+    }
+
+    #[test]
+    fn invalid_country_code_error_displays_input() {
+        let error = Sut::new("toolong").unwrap_err();
+        assert!(error.to_string().contains("toolong"));
+    }
+}

--- a/crates/foundation/src/models/mod.rs
+++ b/crates/foundation/src/models/mod.rs
@@ -1,6 +1,8 @@
+mod bank_holidays;
 mod cadence;
 mod company_information;
 mod cost;
+mod country_code;
 mod currency;
 mod date;
 mod day;
@@ -25,9 +27,11 @@ mod unit_price;
 mod vat;
 mod year;
 
+pub use bank_holidays::BankHolidays;
 pub use cadence::Cadence;
 pub use company_information::CompanyInformation;
 pub use cost::Cost;
+pub use country_code::{CountryCode, InvalidCountryCode};
 pub use currency::Currency;
 pub use date::Date;
 pub use date::DueInDays;


### PR DESCRIPTION
## Summary

Adds an opt-in **`off_on_bank_holidays`** flag to invoice `ServiceFees`. When enabled, public holidays in the **vendor's country** are deducted from billable working days for **day-** and **hour-**granularity rates (monthly/fortnightly fixed rates are unaffected — a fixed monthly fee doesn't shrink for a holiday).

Closes the feature request to be "off on bank holidays".

## Feasibility outcome

- **API:** [Nager.Date](https://date.nager.at/API) — free, no key, no rate limit, **195 countries** incl. 🇸🇪 SE / 🇺🇸 US / 🇬🇧 GB (verified against the live `AvailableCountries` endpoint). Sweden is fully covered by the global API; the Swedish-specific `dryg.net` is not needed.
- Chosen over the offline `py-holidays-rs` crate (beta, 1★ — supply-chain risk).

## Design (mirrors existing patterns)

- **Online fetch + RON disk-cache fallback**, modeled 1:1 on the existing exchange-rate fetcher. Cache at `~/.klirr/cached_holidays.ron`, keyed `ISO country → year`; repeat runs work offline.
- **Name → ISO mapping:** the vendor's free-text `country` string is resolved via a curated alias table (`Sweden`/`Sverige`→`SE`, `England`/`UK`→`GB`, `USA`→`US`, ~45 countries).
- **Graceful degradation:** an unmappable country or a failed lookup logs a warning and skips the deduction — it never blocks PDF generation.
- **Backward compatible:** flag defaults to `false` and deserializes from legacy RON via `#[serde(default)]`.

## Changes by crate

- **foundation:** `CountryCode` newtype + resolver; `BankHolidays` newtype; `BankHolidaysFetcher` behind a new `bank-holidays` feature; `working_days_between`/`quantity_in_period` now skip holiday dates (holidays on weekends are no-ops).
- **core-invoice:** `ServiceFees.off_on_bank_holidays`; `resolve_bank_holidays` wired into `prepare_invoice_input_data`.
- **cli:** yes/no prompt in the service-fees wizard.

## Tests

- Country resolver (Sweden/UK/US aliases, unknown → `None`).
- Holiday fetch with mocked responses (Public-type filter, cache hit/miss, gibberish-cache reset) — no network in tests.
- `working_days_between` deducting a known holiday; holiday-on-weekend no-op; hours = days×8 deduction.
- `ServiceFees` legacy-RON deserialization (no field → `false`).
- Graceful-degrade path (enabled flag + unmappable country → empty, no network).

All unit + doc tests pass; clippy clean for new code.

> **Note on CI/fixtures:** the `render-typst` image-fixture tests are environment-sensitive (imagemagick) and fail *identically* on a clean `main` on the dev machine (same similarity value), so they're unrelated to this change — samples use the default `flag=false` and render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)